### PR TITLE
Win32 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,13 @@ Keep in mind that this plugin is still under development so configuration keys m
           signs = true,
           update_in_insert = true,
           severity_sort = true,
-      }
+      },
+
+      -- use pty for job communication (MS Windows w/o WSL do not support pty)
+      use_pty = not (vim.fn.has('win32') == 1) and (vim.fn.has('wsl') == 0),
+
+      -- End-Of-File character (MS Windows uses ^Z (EOF), others use ^D (EOT))
+      eof = string.char(((vim.fn.has('win32') == 1) and (vim.fn.has('wsl') == 0)) and 26 or 4)
   }
   ```
 </details>

--- a/lua/qalc/init.lua
+++ b/lua/qalc/init.lua
@@ -56,7 +56,13 @@ local config = {
         signs = true,
         update_in_insert = true,
         severity_sort = true,
-    }
+    },
+
+    -- use pty for job communication (MS Windows w/o WSL do not support pty)
+    use_pty = not (vim.fn.has('win32') == 1) and (vim.fn.has('wsl') == 0),
+
+    -- End-Of-File character (windows uses ^Z (EOF), others use ^D (EOT))
+    eof = string.char(((vim.fn.has('win32') == 1) and (vim.fn.has('wsl') == 0)) and 26 or 4)
 }
 -- }}}
 

--- a/lua/qalc/job.lua
+++ b/lua/qalc/job.lua
@@ -11,14 +11,14 @@ local function start(input, config, callback)
         {
             on_stdout = callback,
             stdout_buffered = true,
-            pty = true,
+            pty = config.use_pty
         }
     )
     -- }}}
 
     -- {{{ send input to job
     -- add EOF as last entry of contents
-    input[#input+1] = [[]]
+    input[#input+1] = config.eof
 
     -- send input
     vim.fn.chansend(jobid, input)
@@ -47,7 +47,7 @@ local function run(namespace, input, config)
         local bufnr = vim.api.nvim_get_current_buf()
 
         -- parse output
-        local parsed = parser.results(bufnr, raw_output, new_input, illegal)
+        local parsed = parser.results(bufnr, raw_output, new_input, illegal, config)
 
         -- display results
         require('qalc.display').update.all(namespace, bufnr, config, parsed)

--- a/lua/qalc/parse.lua
+++ b/lua/qalc/parse.lua
@@ -133,14 +133,15 @@ local function get_results(raw_output, input_length)
 
     -- iterate over lines of raw output starting from input index
     for i = input_length, #raw_output do
-        -- add result to results table
-        results[#results+1] = raw_output[i]
+      -- add result to results table
+      results[#results+1] = raw_output[i]
     end
     -- }}}
 
     -- {{{ trim leading and trailing spaces
     for i, v in pairs(results) do
         -- remove
+        v = string.gsub(v, '\\r$', '') -- trailing CR (left from CRLF on Win32)
         v = string.gsub(v, '^%s+', '') -- leading
         v = string.gsub(v, '%s+$', '') -- trailing
 
@@ -234,13 +235,13 @@ end
 -- }}}
 
 -- {{{ parse results
-local function parse_results(bufnr, raw_output, inputs, illegal)
+local function parse_results(bufnr, raw_output, inputs, illegal, config)
     -- {{{ prepare
     -- create table
     local parsed = { results = {}, diagnostics = {} }
 
     -- get only the results
-    local results = get_results(raw_output, #inputs)
+    local results = get_results(raw_output, config.pty and #inputs or 1)
     results[#results] = nil -- remove last newline
     results = prepare_results(results) -- make terse
 

--- a/lua/qalc/parse.lua
+++ b/lua/qalc/parse.lua
@@ -133,8 +133,8 @@ local function get_results(raw_output, input_length)
 
     -- iterate over lines of raw output starting from input index
     for i = input_length, #raw_output do
-      -- add result to results table
-      results[#results+1] = raw_output[i]
+        -- add result to results table
+        results[#results+1] = raw_output[i]
     end
     -- }}}
 


### PR DESCRIPTION
Adds support for Win32 where PTY does not work (therefore no writeback from stdin to stdout happing) and Windows using CRLF as line delimiter (which is not handled correctly by nvim's job implementation) and Ctrl-Z for EOF.