### PR TITLE
Add variable to no output commands

### DIFF
--- a/lua/qalc/parse.lua
+++ b/lua/qalc/parse.lua
@@ -44,6 +44,7 @@ local no_output_cmds = {
     '^function',
     '^MC$', '^MS$', '^M%+$', '^M%-$',
     '^save',
+    '^variable',
 }
 -- }}}
 


### PR DESCRIPTION
Allows buffers like this:

```
variable foo $100
foo * 100
```

Which will output $10000